### PR TITLE
Move away from replaceWebpackConfig

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { createFilePath } = require(`gatsby-source-filesystem`);
 const { copy } = require('fs-extra');
-const componentWithMDXScope = require('gatsby-mdx/component-with-mdx-scope')
 
 // Method that creates nodes based on the file system that we can use in our templates
 exports.onCreateNode = ({ node, getNode, actions }) => {
@@ -106,28 +105,15 @@ exports.createPages = ({ actions, graphql }) => {
   });
 };
 
-exports.onCreateWebpackConfig = ({ actions, getConfig, stage }) => {
-  const config = getConfig();
-  const { module } = config;
-  const { rules } = module;
-  actions.replaceWebpackConfig({
-    ...config,
+exports.onCreateWebpackConfig = ({ actions, getConfig, stage, loaders }) => {
+  actions.setWebpackConfig({
     module: {
-      ...module,
       rules: [
-        ...rules.map(item => {
-          const { use } = item;
-          if (
-            !use ||
-            use.every(({ loader }) => !/babel-loader\.js$/i.test(loader))
-          ) {
-            return item;
-          }
-          return {
-            ...item,
-            exclude: /(node_modules|bower-components)[\/\\](?!(ansi-regex)[\/\\]).*/,
-          };
-        }),
+        {
+          test: /\.js/,
+          include: path.dirname(require.resolve('ansi-regex')),
+          use: [loaders.js()],
+        },
         {
           test: /\.md$/,
           loaders: ['html-loader', 'markdown-loader'],

--- a/src/content/getting-started/about-carbon/about-carbon.mdx
+++ b/src/content/getting-started/about-carbon/about-carbon.mdx
@@ -5,7 +5,7 @@ internal: false
 tabs: ['Overview', 'Usage']
 ---
 
-import PageHeader from '../../components/PageHeader'
+import PageHeader from '../../../components/PageHeader'
 
 <PageHeader title="About Carbon" />
 


### PR DESCRIPTION
Moved away from `replaceWebpackConfig` in favor of a less intrusive
approach using `setWebpackConfig`. This is useful because plugins in
the Gatsby ecosystem (such as `gatsby-mdx`) have access to modify the
webpack config as well, and `setWebpackConfig` composes configuration
well, while `replaceWebpackConfig` causes the user to need to take
account of every plugin that could be adding additional configuration.

Also fixed a path import in an MDX file.

https://www.gatsbyjs.org/docs/add-custom-webpack-config/