### PR TITLE
working MDX globalScope

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,13 +19,21 @@ module.exports = {
         defaultLayouts: {
           default: require.resolve('./src/components/Layouts/index.js'),
         },
-        /*    globalScope: `
-          import { Button } from 'carbon-components-react';
-          export default { Button };
-          import FeatureTile from '${__dirname}/src/components/FeatureTile';
-          import ClickableTile from '${__dirname}/src/components/ClickableTile';
-          import GridWrapper from '${__dirname}/src/components/GridWrapper';
-        `, */
+        globalScope: `
+        import AnchorLinks from '${__dirname}/src/components/AnchorLinks';
+        import { Button } from 'carbon-components-react';
+        import ClickableTile from '${__dirname}/src/components/ClickableTile';
+        import FeatureTile from '${__dirname}/src/components/FeatureTile';
+        import GridWrapper from '${__dirname}/src/components/GridWrapper';
+
+        export default {
+          AnchorLinks,
+          Button,
+          ClickableTile,
+          FeatureTile,
+          GridWrapper
+        };
+      `,
         gatsbyRemarkPlugins: [
           /* { resolve: 'gatsby-remark-unwrap-images' },
           {

--- a/src/components/markdown/Markdown.js
+++ b/src/components/markdown/Markdown.js
@@ -33,10 +33,11 @@ export class h2 extends React.Component {
     return (
       <Location>
         {({ location }) => {
+          console.log(this.props.children)
           const hash =
-            typeof this.props.children[0] !== 'string'
+            typeof this.props.children !== 'string'
               ? undefined
-              : this.props.children[0]
+              : this.props.children
                   .replace(/[:&?’‘“”'",.]/g, '')
                   .toLowerCase()
                   .split(' ')
@@ -73,9 +74,9 @@ export class h3 extends React.Component {
       <Location>
         {({ location }) => {
           const hash =
-            typeof this.props.children[0] !== 'string'
+            typeof this.props.children !== 'string'
               ? undefined
-              : this.props.children[0]
+              : this.props.children
                   .replace(/[:&?’‘“”'",.]/g, '')
                   .toLowerCase()
                   .split(' ')
@@ -110,9 +111,9 @@ export class h4 extends React.Component {
       <Location>
         {({ location }) => {
           const hash =
-            typeof this.props.children[0] !== 'string'
+            typeof this.props.children !== 'string'
               ? undefined
-              : this.props.children[0]
+              : this.props.children
                   .replace(/[:&?’‘“”'",.]/g, '')
                   .toLowerCase()
                   .split(' ')

--- a/src/content/getting-started/about-carbon/about-carbon.mdx
+++ b/src/content/getting-started/about-carbon/about-carbon.mdx
@@ -3,8 +3,6 @@ title: About
 internal: false
 ---
 
-import AnchorLinks from '../../../../src/components/AnchorLinks';
-
 <AnchorLinks>
 
 - [Introduction](#introduction)


### PR DESCRIPTION
Working globalScope with proof-of-concept using `about-carbon.mdx` and `AnchorLinks`

#### Changelog

**New**

- gatsby-mdx `globalScope`

**Changed**

- header link hash creation fix (was truncating title to 1 character)